### PR TITLE
logging.LogRecord does not have `extra` field at init: https://github…

### DIFF
--- a/aiologger/logger.py
+++ b/aiologger/logger.py
@@ -220,8 +220,11 @@ class Logger(Filterer):
             exc_info=exc_info,
             func=func,
             sinfo=sinfo,
-            extra=extra,
         )
+
+        if isinstance(extra, dict):
+            record.__dict__.update(extra)
+
         await self.handle(record)
 
     def __make_dummy_task(self) -> Task:


### PR DESCRIPTION
….com/python/cpython/blob/master/Lib/logging/__init__.py#L284

So, LogRecord inits absolutly differently (and it seems some wierd): https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L402